### PR TITLE
Threads: Ajout des fonctions pour pthread_t

### DIFF
--- a/src/healthcheck/Threads.cpp
+++ b/src/healthcheck/Threads.cpp
@@ -30,6 +30,10 @@ void Threads::add() {
     Threads::add(i);
 }
 
+void Threads::add(pthread_t thread) {
+  const long unsigned int thread_id = (long unsigned int) thread;
+  Threads::add(thread_id);
+}
 void Threads::add(long unsigned int i) {
     BOOST_LOG_TRIVIAL(debug) << "add" << "(call thread " << i << ")";
     m_threads.insert(std::make_pair<long unsigned int, InfoThread>(std::move(i), InfoThread(i)));
@@ -38,6 +42,11 @@ void Threads::add(long unsigned int i) {
 void Threads::status(ThreadStatus::eStatus value) {
     pthread_t i = pthread_self();
     Threads::status(i, value);
+}
+
+void Threads::status(pthread_t thread, ThreadStatus::eStatus value) {
+  const long unsigned int thread_id = (long unsigned int) thread;
+  Threads::status(thread_id, value);
 }
 
 void Threads::status(long unsigned int i, ThreadStatus::eStatus value) {

--- a/src/healthcheck/Threads.h
+++ b/src/healthcheck/Threads.h
@@ -1,6 +1,7 @@
 #include <string>
 #include <map>
 #include <chrono>
+#include <pthread.h>
 
 #include "InfoThread.h"
 #include "../Request.h"
@@ -62,6 +63,7 @@ class Threads {
          */
         static void add();
         static void add(long unsigned int);
+        static void add(pthread_t);
 
         /**
          * @brief Update thread information (request, ...)
@@ -81,6 +83,7 @@ class Threads {
          */
         static void status(ThreadStatus::eStatus);
         static void status(long unsigned int, ThreadStatus::eStatus);
+        static void status(pthread_t, ThreadStatus::eStatus);
 
         /**
          * @brief Show status of all threads in JSON format


### PR DESCRIPTION
Les fonctions add et status attendent des "long unsigned int", toutefois il n'existe pas de cast automatique entre celles-ci et les pthread_t envoyés dans Rok4Server.cpp.

La PR ajoute ces deux fonctions.