### PR TITLE
Correction de la copie de MetadataURL

### DIFF
--- a/src/MetadataURL.h
+++ b/src/MetadataURL.h
@@ -112,6 +112,8 @@ public:
      * \param[in] origMtdUrl MetadataURL to copy
      */
     MetadataURL ( const MetadataURL & origMtdUrl ) : ResourceLocator ( origMtdUrl ) {
+        href = origMtdUrl.href;
+        format = origMtdUrl.format;
         type = origMtdUrl.type;
     };
     /**

--- a/src/UtilsWMS.cpp
+++ b/src/UtilsWMS.cpp
@@ -860,7 +860,7 @@ void Rok4Server::buildWMSCapabilities() {
                             styleEl->LinkEndChild ( UtilsXML::buildTextNode ( "Abstract", style->getAbstracts() [j].c_str() ) );
                         }
                         for ( j=0 ; j < style->getLegendURLs().size(); ++j ) {
-                            BOOST_LOG_TRIVIAL(debug) <<  "LegendURL" << style->getId()  ;
+                            BOOST_LOG_TRIVIAL(debug) <<  "LegendURL " << style->getId()  ;
                             LegendURL legendURL = style->getLegendURLs() [j];
                             TiXmlElement* legendURLEl = new TiXmlElement ( "LegendURL" );
 


### PR DESCRIPTION
### [Fixed]

* La fonction de copie d'une instance MetadataURL recopie bien le format et le href