### PR TITLE
Feature/services metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ![ROK4 Logo](https://rok4.github.io/assets/images/rok4.png)
 
-Le serveur implémente les standards ouverts de l’Open Geospatial Consortium (OGC) WMS 1.3.0 et WMTS 1.0.0, ainsi que le TMS (Tile Map Service). Il vise deux objectifs principaux :
+Le serveur implémente les standards ouverts de l’Open Geospatial Consortium (OGC) WMS 1.3.0, WMTS 1.0.0 et OGC API Tiles 1.0.0, ainsi que le TMS (Tile Map Service). Il vise deux objectifs principaux :
 
-* L’utilisation d’un cache de données raster unique permettant de servir indifféremment des flux WMS, WMTS et TMS
+* L’utilisation d’un cache de données raster unique permettant de servir indifféremment des flux WMS, WMTS, API Tiles et TMS
 * Des performances de traitement d’image et de diffusion accrues
 * La diffusion de tuiles vecteur telles qu'elles sont stockées, sans transformation (TMS uniquement)
 * La diffusion en WMTS selon des Tile Matrix Sets différents de celui de la pyramide utilisée.
@@ -165,6 +165,7 @@ On redémarre nginx : `systemctl restart nginx`
     - WMS : http://localhost/rok4/wms?request=GetCapabilities&service=WMS
     - WMTS : http://localhost/rok4/wmts?request=GetCapabilities&service=WMTS
     - TMS : http://localhost/rok4/tms/1.0.0
+    - OGC API Tiles : http://localhost/rok4/ogcapitiles/collections
 * Racine de l'API d'administration : http://localhost/rok4/admin/
 * État de santé du serveur : http://localhost/rok4/healthcheck
 
@@ -178,6 +179,7 @@ Lorsque le serveur reçoit une requête, c'est le premier élément du chemin qu
 * `/healthcheck` -> requête d'état de santé ou statut du serveur
 * `/wmts` -> requête WMTS
 * `/wms` -> requête WMS
+* `/ogcapitiles` -> requête API Tiles
 * `/tms` -> requête TMS
 * `/admin` -> requête d'administration
 
@@ -227,6 +229,9 @@ Pour que les URLs présentes dans les réponses des services soient correctes ma
     },
     "tms": {
         "endpoint_uri": "http://localhost/rok4/tms"
+    },
+    "ogctiles": {
+        "endpoint_uri": "http://localhost/rok4/ogcapitiles"
     }
 ```
 

--- a/config/services.schema.json
+++ b/config/services.schema.json
@@ -159,7 +159,8 @@
                 },
                 "endpoint_uri": {
                     "type": "string"
-                }
+                },
+                "metadata": { "$ref": "#/$defs/metadata" }
             }
         },
         "ogctiles": {
@@ -170,7 +171,8 @@
                 },
                 "endpoint_uri": {
                     "type": "string"
-                }
+                },
+                "metadata": { "$ref": "#/$defs/metadata" }
             }
         }
     },

--- a/src/ServicesConf.cpp
+++ b/src/ServicesConf.cpp
@@ -680,6 +680,15 @@ bool ServicesConf::parse(json11::Json& doc) {
         } else {
             ogctilesPublicUrl = "/ogcapitiles";
         }
+
+        // Métadonnée
+        if (ogcSection["metadata"].is_object()) {
+            mtdOGCTILES = new MetadataURL ( ogcSection["metadata"] );
+            if (mtdOGCTILES->getMissingField() != "") {
+                errorMessage = "Invalid OGC TIles metadata: have to own a field " + mtdOGCTILES->getMissingField();
+                return false;
+            }
+        }
         
     }
 
@@ -741,6 +750,7 @@ ServicesConf::~ServicesConf(){
     delete mtdWMS;
     delete mtdWMTS;
     delete mtdTMS;
+    delete mtdOGCTILES;
 
     for ( unsigned int l = 0; l < listofequalsCRS.size(); l++ ) {
         for ( unsigned int c = 0; c < listofequalsCRS.at(l).size(); c++ ) {

--- a/src/ServicesConf.cpp
+++ b/src/ServicesConf.cpp
@@ -582,6 +582,9 @@ bool ServicesConf::parse(json11::Json& doc) {
                 errorMessage = "Invalid WMS metadata: have to own a field " + mtdWMS->getMissingField();
                 return false;
             }
+        } else if (inspire) {
+            errorMessage = "Inspire WMS service require a metadata";
+            return false;
         }
         
     }
@@ -618,6 +621,9 @@ bool ServicesConf::parse(json11::Json& doc) {
                 errorMessage = "Invalid WMTS metadata: have to own a field " + mtdWMTS->getMissingField();
                 return false;
             }
+        } else if (inspire) {
+            errorMessage = "Inspire WMTS service require a metadata";
+            return false;
         }
         
     }
@@ -688,6 +694,9 @@ bool ServicesConf::parse(json11::Json& doc) {
                 errorMessage = "Invalid OGC TIles metadata: have to own a field " + mtdOGCTILES->getMissingField();
                 return false;
             }
+        } else if (inspire) {
+            errorMessage = "Inspire OGC API Tiles service require a metadata";
+            return false;
         }
         
     }
@@ -696,6 +705,8 @@ bool ServicesConf::parse(json11::Json& doc) {
 }
 
 ServicesConf::ServicesConf(std::string path) : Configuration(path) {
+
+    mtdOGCTILES = 0, mtdTMS = 0, mtdWMS = 0, mtdWMTS = 0;
 
     std::cout << "Loading services configuration from file " << filePath << std::endl;
 
@@ -747,10 +758,10 @@ bool ServicesConf::are_the_two_CRS_equal( std::string crs1, std::string crs2 ) {
 }
 
 ServicesConf::~ServicesConf(){ 
-    delete mtdWMS;
-    delete mtdWMTS;
-    delete mtdTMS;
-    delete mtdOGCTILES;
+    if (mtdWMS) {delete mtdWMS;}
+    if (mtdWMTS) {delete mtdWMTS;}
+    if (mtdTMS) {delete mtdTMS;}
+    if (mtdOGCTILES) {delete mtdOGCTILES;}
 
     for ( unsigned int l = 0; l < listofequalsCRS.size(); l++ ) {
         for ( unsigned int c = 0; c < listofequalsCRS.at(l).size(); c++ ) {

--- a/src/ServicesConf.h
+++ b/src/ServicesConf.h
@@ -156,11 +156,12 @@ class ServicesConf : public Configuration
         // ----------------------- OGC Tiles
 
         /**
-         * \~french \brief Définit si le serveur doit honorer les requêtes OGC
+         * \~french \brief Définit si le serveur doit honorer les requêtes OGC Tiles
          * \~english \brief Define whether OGC request should be honored
          */
         bool supportOGCTILES;
         std::string ogctilesPublicUrl;
+        MetadataURL* mtdOGCTILES;
 
         // ----------------------- WMS 
         /**

--- a/src/UtilsOGCTILES.cpp
+++ b/src/UtilsOGCTILES.cpp
@@ -83,8 +83,19 @@ void Rok4Server::buildOGCTILESCapabilities() {
     res_coll << "      \"type\": \"application/json\",\n";
     res_coll << "      \"title\": \"this document\",\n";
     res_coll << "      \"templated\": false\n";
-    res_coll << "    }\n";
-    res_coll << "  ],\n";
+    res_coll << "    }";
+
+    if ( servicesConf->mtdOGCTILES ) {
+        res_coll << ",\n";
+        res_coll << "    {\n";
+        res_coll << "      \"href\": \"" << servicesConf->mtdOGCTILES->getHRef() << "\",\n";
+        res_coll << "      \"type\": \"" << servicesConf->mtdOGCTILES->getType() << "\",\n";
+        res_coll << "      \"rel\": \"describedby\",\n";
+        res_coll << "      \"title\": \"Service metadata\"\n";
+        res_coll << "    }\n";
+    }
+
+    res_coll << "\n  ],\n";
     res_coll << "  \"collections\" : [\n";
 
     // Layers

--- a/src/UtilsTMS.cpp
+++ b/src/UtilsTMS.cpp
@@ -406,6 +406,11 @@ void Rok4Server::buildTMSCapabilities() {
     tmsCapabilities += "<TileMapService version=\"1.0.0\" services=\"" + servicesConf->tmsPublicUrl + "\">\n";
     tmsCapabilities += "  <Title>" + servicesConf->title + "</Title>\n";
     tmsCapabilities += "  <Abstract>" + servicesConf->abstract + "</Abstract>\n";
+
+    if ( servicesConf->mtdTMS ) {
+        tmsCapabilities += "  <Metadata type=\"" + servicesConf->mtdTMS->getType() + "\" mime-type=\"text/xml\" href=\"" + servicesConf->mtdTMS->getHRef() + "\" />\n";
+    }
+
     tmsCapabilities += "  <TileMaps>\n";
 
     std::map<std::string, Layer*>::iterator itLay ( serverConf->layersList.begin() ), itLayEnd ( serverConf->layersList.end() );

--- a/src/UtilsWMS.cpp
+++ b/src/UtilsWMS.cpp
@@ -607,7 +607,7 @@ void Rok4Server::buildWMSCapabilities() {
     capabilityEl->LinkEndChild ( exceptionEl );
 
     // Inspire (extended Capability)
-    if ( servicesConf->inspire ) {
+    if ( servicesConf->mtdWMS ) {
         // TODO : en dur. A mettre dans la configuration du service (prevoir differents profils d'application possibles)
         TiXmlElement * extendedCapabilititesEl = new TiXmlElement ( "inspire_vs:ExtendedCapabilities" );
 

--- a/src/UtilsWMTS.cpp
+++ b/src/UtilsWMTS.cpp
@@ -379,7 +379,7 @@ void Rok4Server::buildWMTSCapabilities() {
 
     // Inspire (extended Capability)
     // TODO : en dur. A mettre dans la configuration du service (prevoir differents profils d'application possibles)
-    if ( servicesConf->inspire ) {
+    if ( servicesConf->mtdWMTS) {
         TiXmlElement * extendedCapabilititesEl = new TiXmlElement ( "inspire_vs:ExtendedCapabilities" );
 
         // MetadataURL


### PR DESCRIPTION
### [Added]

* Gestion de la métadonnée de service pour l'OGC API Tiles

### [Changed]

* Pour le WMS, WMTS et OGC API Tiles, la fourniture d'une métadonnée de service est obligatoire dans le cas inspire
* Pour tous les services de diffusion, si une métadonnée de service est fournie, elle est mise dans la réponse au GetCapabilities