### PR TITLE
Écriture des décimales des nombres flottants dans les réponses au GetFeatureInfo

### DIFF
--- a/src/Rok4Server.cpp
+++ b/src/Rok4Server.cpp
@@ -674,6 +674,7 @@ DataStream* Rok4Server::CommonGetFeatureInfo(std::string service, Layer* layer, 
                 image->getline(floatbuffer, 0);
                 for (int i = 0; i < n; i++) {
                     std::stringstream ss;
+                    ss.setf ( std::ios::fixed,std::ios::floatfield );
                     ss << (float)floatbuffer[i];
                     strData.push_back(ss.str());
                 }


### PR DESCRIPTION
### [Fixed]

* Lors de l'écriture de nombres flottants dans les réponses à un appel GetFeatureInfo, on précise les décimales