### PR TITLE
Meilleure gestion des limites d'une couche

### DIFF
--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -476,20 +476,11 @@ bool Layer::parse(json11::Json& doc, ServicesConf* servicesConf) {
 
 void Layer::calculateBoundingBoxes() {
 
-    // On calcule la bbox à partir des tuiles limites des niveaux de la pyramide
+    // On calcule la bbox à partir des tuiles limites du niveau le mieux résolu de la pyramide
     std::set<std::pair<std::string, Level*>, ComparatorLevel> orderedLevels = dataPyramid->getOrderedLevels(true);
-    bool first = true;
-    for (std::pair<std::string, Level*> element : orderedLevels) {
-        Level * level = element.second;
 
-        if (first) {
-            boundingBox = BoundingBox<double>(level->getBboxFromTileLimits());
-            first = false;
-            continue;
-        }
-
-        boundingBox = boundingBox.getUnion(level->getBboxFromTileLimits());
-    }
+    Level * level = orderedLevels.begin()->second;
+    boundingBox = BoundingBox<double>(level->getBboxFromTileLimits());
     boundingBox.crs = dataPyramid->getTms()->getCrs()->getRequestCode();
 
     geographicBoundingBox = BoundingBox<double>(boundingBox);
@@ -578,7 +569,7 @@ void Layer::calculateExtraTileMatrixLimits() {
         newList.push_back(tms);
     }
 
-    // La nouvelle liste ne contient pas les TMS pour lesquels nous n'avons pas pu calculer les liveaux et les limites
+    // La nouvelle liste ne contient pas les TMS pour lesquels nous n'avons pas pu calculer les niveaux et les limites
     WMTSTMSList = newList;
 }
 

--- a/src/UtilsXML.h
+++ b/src/UtilsXML.h
@@ -98,10 +98,10 @@ class UtilsXML
 
 
         /**
-         * \~french \brief Export XML du mot clé pour le GetCapabilities
-         * \param[in] elName Nom de l'élément XML
-         * \~english \brief Keyword XML export for GetCapabilities
-         * \param[in] elName XML element name
+         * \~french \brief Export XML des tuiles limites pour un niveau
+         * \param[in] tml Tuiles limites du niveau
+         * \~english \brief XML export for tiles' limits for a level
+         * \param[in] tml Level's tiles limits
          */
         static TiXmlElement* getXml(TileMatrixLimits tml) {
             TiXmlElement* tmLimitsEl = new TiXmlElement ( "TileMatrixLimits" );


### PR DESCRIPTION
### [Changed]

* `Layer` : si aucune bbox n'est fournie, elle est déduite du niveau le mieux résolu des pyramides utilisées par la couche * Dans le getcapabilities WMTS, dans le cas de TMS additionnel pour une couche, on ajoute une marge de une tuile pour les tuiles limites calculées