### PR TITLE
Version par défaut en WMTS (1.0.0) et WMS (1.3.0)

### DIFF
--- a/src/UtilsWMS.cpp
+++ b/src/UtilsWMS.cpp
@@ -78,7 +78,7 @@ DataStream* Rok4Server::getMapParamWMS (
     // VERSION
     std::string version = request->getParam ( "version" );
     if ( version == "" ) {
-        return new SERDataStream ( new ServiceException ( "",OWS_MISSING_PARAMETER_VALUE,"Parametre VERSION absent.","wms" ) );
+        version = "1.3.0";
     }
 
     if ( version != "1.3.0" )
@@ -415,7 +415,7 @@ DataStream* Rok4Server::getCapParamWMS ( Request* request, std::string& version 
     // VERSION
     version = request->getParam ( "version" );
     if ( version == "" ) {
-        return new SERDataStream ( new ServiceException ( "",OWS_MISSING_PARAMETER_VALUE,"Parametre VERSION absent.","wms" ) );
+        version = "1.3.0";
     }
 
     if ( version != "1.3.0" )

--- a/src/UtilsWMTS.cpp
+++ b/src/UtilsWMTS.cpp
@@ -60,7 +60,7 @@ DataSource* Rok4Server::getTileParamWMTS ( Request* request, Layer*& layer, Tile
     // VERSION
     std::string version = request->getParam ( "version" );
     if ( version == "" ) {
-        return new SERDataSource ( new ServiceException ( "",OWS_MISSING_PARAMETER_VALUE,"Parametre VERSION absent.","wmts" ) );
+        version = "1.0.0";
     }
 
     if ( version != "1.0.0" )
@@ -630,7 +630,7 @@ DataStream* Rok4Server::getCapParamWMTS ( Request* request, std::string& version
     
     version = request->getParam ( "version" );
     if ( version == "" ) {
-        return new SERDataStream ( new ServiceException ( "",OWS_MISSING_PARAMETER_VALUE,"Parametre VERSION absent.","wmts" ) );
+        version = "1.0.0";
     }
 
     if ( version != "1.0.0" )


### PR DESCRIPTION
### [Changed]

* En WMS, si la requête ne précise pas de version, on met la version 1.3.0 par défaut
* En WMTS, si la requête ne précise pas de version, on met la version 1.0.0 par défaut