### PR TITLE
Gestion de la réecriture des capacités des services

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1378,6 +1378,17 @@ paths:
 
   ######################################### ADMIN
 
+  /admin/layers:
+    put:
+      tags:
+      - Administration
+      summary: Re-génére les capacités des services
+      operationId: admin_build_capabilities
+
+      responses:
+        204:
+          description: Réécriture des capacités réussie
+
   /admin/layers/{layername}:
     post:
       tags:
@@ -1391,6 +1402,13 @@ paths:
           description: Identifiant de la nouvelle couche
           schema:
             type: string
+        - name: build_capabilities
+          required: false
+          in: query
+          description: Doit-on re-générer les capacités des services (oui par défaut)
+          schema:
+            type: boolean
+            default: true
 
 
       requestBody:
@@ -1427,6 +1445,13 @@ paths:
           description: Identifiant de la couche à modifier
           schema:
             type: string
+        - name: build_capabilities
+          required: false
+          in: query
+          description: Doit-on re-générer les capacités des services (oui par défaut)
+          schema:
+            type: boolean
+            default: true
 
       requestBody:
         content:  
@@ -1462,6 +1487,13 @@ paths:
           description: Identifiant de la couche à supprimer
           schema:
             type: string
+        - name: build_capabilities
+          required: false
+          in: query
+          description: Doit-on re-générer les capacités des services (oui par défaut)
+          schema:
+            type: boolean
+            default: true
 
       responses:
         204:

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -75,6 +75,7 @@ namespace RequestType {
         "AddLayer",
         "UpdateLayer",
         "DeleteLayer",
+        "BuildCapabilities",
         "GetStatus",
         "GetInfos"
         "GetThreads",
@@ -876,6 +877,11 @@ void Request::determineServiceAndRequest() {
         if (method == "POST" && pathParts.size() == 3 && pathParts.at(1) == "layers") {
             //--> POST /admin/layers/{layername}
             request = RequestType::ADDLAYER;
+        }
+
+        else if (method == "PUT" && pathParts.size() == 2 && pathParts.at(1) == "layers") {
+            //--> PUT /admin/layers
+            request = RequestType::BUILDCAPABILITIES;
         }
 
         else if (method == "PUT" && pathParts.size() == 3 && pathParts.at(1) == "layers") {

--- a/src/Request.h
+++ b/src/Request.h
@@ -80,6 +80,7 @@ namespace RequestType {
         ADDLAYER,
         UPDATELAYER,
         DELETELAYER,
+        BUILDCAPABILITIES,
         GETHEALTHSTATUS,
         GETINFOSTATUS,
         GETTHREADSTATUS,

--- a/src/Rok4Server.cpp
+++ b/src/Rok4Server.cpp
@@ -800,6 +800,8 @@ void Rok4Server::processTMS(Request* request, FCGX_Request& fcgxRequest) {
 void Rok4Server::processAdmin(Request* request, FCGX_Request& fcgxRequest) {
     if (request->request == RequestType::ADDLAYER) {
         S.sendresponse(AdminCreateLayer(request), &fcgxRequest);
+    } else if (request->request == RequestType::BUILDCAPABILITIES) {
+        S.sendresponse(AdminBuildCapabilities(request), &fcgxRequest);
     } else if (request->request == RequestType::UPDATELAYER) {
         S.sendresponse(AdminUpdateLayer(request), &fcgxRequest);
     } else if (request->request == RequestType::DELETELAYER) {

--- a/src/Rok4Server.h
+++ b/src/Rok4Server.h
@@ -474,6 +474,18 @@ private:
 
     /**
      * \~french
+     * \brief Traitement d'une requête de réécriture des capacités
+     * \param[in] request représentation de la requête
+     * \return flux de la réponse
+     * \~english
+     * \brief Process a BuildCapabilities admin request
+     * \param[in] request request representation
+     * \return response stream
+     */
+    DataStream* AdminBuildCapabilities ( Request* request );
+
+    /**
+     * \~french
      * \brief Traitement d'une requête de suppression de couche
      * \param[in] request représentation de la requête
      * \return flux de la réponse

--- a/src/UtilsAdmin.cpp
+++ b/src/UtilsAdmin.cpp
@@ -75,7 +75,32 @@ DataStream* Rok4Server::AdminCreateLayer ( Request* request ) {
 
     serverConf->addLayer ( layer );
 
+
+    if (request->getParam("build_capabilities") != "false") {
+        // On recalcule les GetCapabilities
+        BOOST_LOG_TRIVIAL(debug) << "Services capabilities build"  ;
+        if ( servicesConf->supportWMS ) {
+            buildWMSCapabilities();
+        }
+        if ( servicesConf->supportWMTS ) {
+            buildWMTSCapabilities();
+        }
+        if ( servicesConf->supportTMS ) {
+            buildTMSCapabilities();
+        }
+        if ( servicesConf->supportOGCTILES ) {
+            buildOGCTILESCapabilities();
+        }
+    }
+
+    return new EmptyResponseDataStream ();
+}
+
+
+DataStream* Rok4Server::AdminBuildCapabilities ( Request* request ) {
+
     // On recalcule les GetCapabilities
+    BOOST_LOG_TRIVIAL(debug) << "Services capabilities build"  ;
     if ( servicesConf->supportWMS ) {
         buildWMSCapabilities();
     }
@@ -105,18 +130,21 @@ DataStream* Rok4Server::AdminDeleteLayer ( Request* request ) {
 
     serverConf->removeLayer ( layer->getId() );
 
-    // On recalcule les GetCapabilities
-    if ( servicesConf->supportWMS ) {
-        buildWMSCapabilities();
-    }
-    if ( servicesConf->supportWMTS ) {
-        buildWMTSCapabilities();
-    }
-    if ( servicesConf->supportTMS ) {
-        buildTMSCapabilities();
-    }
-    if ( servicesConf->supportOGCTILES ) {
-        buildOGCTILESCapabilities();
+    if (request->getParam("build_capabilities") != "false") {
+        // On recalcule les GetCapabilities
+        BOOST_LOG_TRIVIAL(debug) << "Services capabilities build"  ;
+        if ( servicesConf->supportWMS ) {
+            buildWMSCapabilities();
+        }
+        if ( servicesConf->supportWMTS ) {
+            buildWMTSCapabilities();
+        }
+        if ( servicesConf->supportTMS ) {
+            buildTMSCapabilities();
+        }
+        if ( servicesConf->supportOGCTILES ) {
+            buildOGCTILESCapabilities();
+        }
     }
 
     return new EmptyResponseDataStream ();
@@ -142,18 +170,23 @@ DataStream* Rok4Server::AdminUpdateLayer ( Request* request ) {
     serverConf->removeLayer ( layer->getId() );
     serverConf->addLayer ( newLayer );
 
-    // On recalcule les GetCapabilities
-    if ( servicesConf->supportWMS ) {
-        buildWMSCapabilities();
-    }
-    if ( servicesConf->supportWMTS ) {
-        buildWMTSCapabilities();
-    }
-    if ( servicesConf->supportTMS ) {
-        buildTMSCapabilities();
-    }
-    if ( servicesConf->supportOGCTILES ) {
-        buildOGCTILESCapabilities();
+    if (request->getParam("build_capabilities") != "false") {
+        // On recalcule les GetCapabilities
+        BOOST_LOG_TRIVIAL(debug) << "Services capabilities build"  ;
+
+        // On recalcule les GetCapabilities
+        if ( servicesConf->supportWMS ) {
+            buildWMSCapabilities();
+        }
+        if ( servicesConf->supportWMTS ) {
+            buildWMTSCapabilities();
+        }
+        if ( servicesConf->supportTMS ) {
+            buildTMSCapabilities();
+        }
+        if ( servicesConf->supportOGCTILES ) {
+            buildOGCTILESCapabilities();
+        }
     }
 
     return new EmptyResponseDataStream ();


### PR DESCRIPTION
### [Added]

* Sur les routes admin de ajout, modification et suppression de couche, on peut demander que les capacités des services ne soient pas regénérés
* Un nouvelle route admin (PUT /admin/layers) sans paramètre permet de demander la réécriture des capacités des services