### PR TITLE
Ajout d'un mécanisme d'activation/désactivation des services

### DIFF
--- a/config/server.schema.json
+++ b/config/server.schema.json
@@ -15,6 +15,11 @@
             "type": "integer",
             "description": "Taille de la file d'attente du socket"
         },
+        "enabled": {
+            "type": "boolean",
+            "description": "Active-t-on les API de consultation automatiquement à la fin du chargement ?",
+            "default": true
+        },
         "api": {
             "type": "boolean",
             "description": "Active-t-on l'API d'administration"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -47,10 +47,10 @@ paths:
     get:
       tags:
       - Santé du serveur
-      summary: ...
+      summary: Récupère les informations générales du serveur
       responses:
         200:
-          description: ...
+          description: Statut, version, identifiant de processus et date de lancement
           content:
             application/json:
               schema:
@@ -60,10 +60,10 @@ paths:
     get:
       tags:
       - Santé du serveur
-      summary: ...
+      summary: Récupère la liste des identifiants des couches, TMS et styles chargés
       responses:
         200:
-          description: ...
+          description: Liste des identifiants des couches, TMS et styles chargés
           content:
             application/json:
               schema:
@@ -73,10 +73,10 @@ paths:
     get:
       tags:
       - Santé du serveur
-      summary: ...
+      summary: Récupère les informations sur chaque thread
       responses:
         200:
-          description: ...
+          description: Liste des identifiants, statuts, nombre et temps de traitement des requête pour chaque thread
           content:
             application/json:
               schema:
@@ -86,10 +86,10 @@ paths:
     get:
       tags:
       - Santé du serveur
-      summary: ...
+      summary: Récupère le compte des contextes de stockage utilisés
       responses:
         200:
-          description: ...
+          description: Nombre de contexte de stockage utilisés fichier, Swift, S3 et Ceph 
           content:
             application/json:
               schema:
@@ -1378,6 +1378,32 @@ paths:
 
   ######################################### ADMIN
 
+  /admin/on:
+    put:
+      tags:
+      - Administration
+      summary: Active les services
+      description: On active la réponse aux appels sur les routes globales et de consultation
+      operationId: admin_turn_on
+
+      responses:
+        204:
+          description: Activation des services réussie
+
+  /admin/off:
+    put:
+      tags:
+      - Administration
+      summary: Désactive les services
+      description: |
+        On désactive la réponse aux appels sur les routes globales et de consultation (réponse d'un 503 systématique). 
+        On répond toujours aux API admin et de santé.
+      operationId: admin_turn_off
+
+      responses:
+        204:
+          description: Désactivation des services réussie
+
   /admin/layers:
     put:
       tags:
@@ -1658,6 +1684,7 @@ components:
       properties:
         status:
           type: string
+          enum: ['OK', 'DISABLED']
         version:
           type: string
         pid:

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -76,6 +76,8 @@ namespace RequestType {
         "UpdateLayer",
         "DeleteLayer",
         "BuildCapabilities",
+        "TurnOn",
+        "TurnOff",
         "GetStatus",
         "GetInfos"
         "GetThreads",
@@ -892,6 +894,18 @@ void Request::determineServiceAndRequest() {
         else if (method == "DELETE" && pathParts.size() == 3 && pathParts.at(1) == "layers") {
             //--> DELETE /admin/layers/{layername}
             request = RequestType::DELETELAYER;
+
+        }
+
+        else if (method == "PUT" && pathParts.size() == 2 && pathParts.at(1) == "on") {
+            //--> PUT /admin/on
+            request = RequestType::TURNON;
+
+        }
+
+        else if (method == "PUT" && pathParts.size() == 2 && pathParts.at(1) == "off") {
+            //--> PUT /admin/off
+            request = RequestType::TURNOFF;
 
         } else {
             // La profondeur de requête ne permet pas de savoir l'action demandée -> ERREUR

--- a/src/Request.h
+++ b/src/Request.h
@@ -81,6 +81,8 @@ namespace RequestType {
         UPDATELAYER,
         DELETELAYER,
         BUILDCAPABILITIES,
+        TURNON,
+        TURNOFF,
         GETHEALTHSTATUS,
         GETINFOSTATUS,
         GETTHREADSTATUS,

--- a/src/ServerConf.cpp
+++ b/src/ServerConf.cpp
@@ -162,6 +162,16 @@ bool ServerConf::parse(json11::Json& doc) {
         supportAdmin = doc["api"].bool_value();
     }
 
+    // api
+    if (doc["enabled"].is_null()) {
+        enabled = true;
+    } else if (! doc["api"].is_bool()) {
+        errorMessage = "enabled have to be a boolean";
+        return false;
+    } else {
+        enabled = doc["enabled"].bool_value();
+    }
+
     // configurations
     json11::Json configurationsSection = doc["configurations"];
     if (configurationsSection.is_null()) {

--- a/src/ServerConf.h
+++ b/src/ServerConf.h
@@ -129,6 +129,13 @@ class ServerConf : public Configuration
          */
         bool supportAdmin;
 
+
+        /**
+         * \~french \brief Définit si le serveur doit honorer les requêtes de consultation
+         * \~english \brief Define whether broadcast request should be honored
+         */
+        bool enabled;
+
     private:
 
         bool parse(json11::Json& doc);

--- a/src/ServiceException.cpp
+++ b/src/ServiceException.cpp
@@ -91,6 +91,10 @@ std::string ServiceException::getCodeAsString ( ExceptionCode code ) {
         return "ConfigurationConflict";
     case ADMIN_BAD_REQUEST:
         return "ConfigurationIssue";
+    case INTERNAL_SERVER_ERROR:
+        return "InternalServerError";
+    case SERVICE_UNAVAILABLE:
+        return "ServiceUnavailable";
     default:
         return "" ;
     }
@@ -121,6 +125,8 @@ int ServiceException::getCodeAsStatusCode ( ExceptionCode code ) {
         return 500 ;
     case OWS_OPERATION_NOT_SUPORTED:
         return 501 ;
+    case SERVICE_UNAVAILABLE:
+        return 503 ;
     case HTTP_NOT_FOUND:
         return 404 ;
     case GFI_PYRAMID_VALUES:
@@ -146,6 +152,8 @@ std::string ServiceException::getStatusCodeAsReasonPhrase ( int statusCode ) {
         return "Internal server error" ;
     case 501 :
         return "Not implemented" ;
+    case 503 :
+        return "Service unavailable" ;
     default : 
         return "No reason";
     }

--- a/src/ServiceException.h
+++ b/src/ServiceException.h
@@ -161,7 +161,12 @@ typedef enum {
      * \~french Erreur interne
      * \~english Internal issue
      */
-    INTERNAL_SERVER_ERROR = 20
+    INTERNAL_SERVER_ERROR = 20,
+    /**
+     * \~french Erreur interne
+     * \~english Internal issue
+     */
+    SERVICE_UNAVAILABLE = 21
 
 } ExceptionCode;
 


### PR DESCRIPTION
### [Added]

* Possbilité d'activer / désactiver les routes de consultation 
    * La configuration serveur permet de dire si les services sont activés à la fin du chargement (oui par défaut) 
    * Toutes les routes globales, WMS, WMTS, TMS et OGC API Tiles répondent en 503 si le serveur est désactiver 
    * 2 routes admin permettent d'activer (`PUT /admin/on`) ou désactiver (`PUT /admin/off`) les services