### PR TITLE
Paramètres additionnels pour le getFeatureInfo avec WMS source

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1872,6 +1872,8 @@ components:
               type: string
             service:
               type: string
+            extra_query_params:
+              type: string
             force_epsg:
               type: boolean
           required:

--- a/src/Layer.cpp
+++ b/src/Layer.cpp
@@ -298,6 +298,9 @@ bool Layer::parse(json11::Json& doc, ServicesConf* servicesConf) {
                     if(doc["get_feature_info"]["force_epsg"].is_bool()) {
                         GFIForceEPSG = doc["get_feature_info"]["force_epsg"].bool_value();
                     }
+                    if(doc["get_feature_info"]["extra_query_params"].is_string()) {
+                        GFIExtraParams = doc["get_feature_info"]["extra_query_params"].string_value();
+                    }
 
                 } 
                 else {
@@ -804,6 +807,7 @@ std::vector<MetadataURL> Layer::getMetadataURLs() { return metadataURLs; }
 bool Layer::isGetFeatureInfoAvailable() { return getFeatureInfoAvailability; }
 std::string Layer::getGFIType() { return getFeatureInfoType; }
 std::string Layer::getGFIBaseUrl() { return getFeatureInfoBaseURL; }
+std::string Layer::getGFIExtraParams() { return GFIExtraParams; }
 std::string Layer::getGFILayers() { return GFILayers; }
 std::string Layer::getGFIQueryLayers() { return GFIQueryLayers; }
 std::string Layer::getGFIService() { return GFIService; }

--- a/src/Layer.h
+++ b/src/Layer.h
@@ -196,7 +196,7 @@ private:
      */
     std::string getFeatureInfoType;
     /**
-     * \~french \brief URL du service WMS-V à utiliser pour le GetFeatureInfo
+     * \~french \brief URL du service WMS à utiliser pour le GetFeatureInfo
      * \~english \brief WMS-V service URL to use for getFeatureInfo
      */
     std::string getFeatureInfoBaseURL;
@@ -220,6 +220,11 @@ private:
      * \~english \brief Parameter layers for the service
      */
     std::string GFILayers;
+    /**
+     * \~french \brief Paramètres de requête additionnels à fournir au service
+     * \~english \brief Additionnal query parameters for the service
+     */
+    std::string GFIExtraParams;
     /**
      * \~french \brief Modification des EPSG autorisé (pour Geoserver)
      * \~english \brief Modification of EPSG is authorized (for Geoserver)
@@ -590,6 +595,15 @@ public:
      * \return version of service used for GFI
      */
     std::string getGFIVersion() ;
+    /**
+     * \~french
+     * \brief Retourne les paramètres de requête additionnels de la requête de GFI
+     * \return paramètres additionnels
+     * \~english
+     * \brief Return the extra query parameters of GFI request
+     * \return extra parameters
+     */
+    std::string getGFIExtraParams() ;
     /**
      * \~french
      * \brief

--- a/src/Rok4Server.cpp
+++ b/src/Rok4Server.cpp
@@ -664,6 +664,7 @@ DataStream* Rok4Server::CommonGetFeatureInfo(std::string service, Layer* layer, 
                     ss << (int)intbuffer[i];
                     strData.push_back(ss.str());
                 }
+                delete[] intbuffer;
                 break;
             }
             case Rok4Format::TIFF_RAW_FLOAT32:
@@ -694,7 +695,7 @@ DataStream* Rok4Server::CommonGetFeatureInfo(std::string service, Layer* layer, 
 
     } else if (getFeatureInfoType.compare("EXTERNALWMS") == 0) {
         BOOST_LOG_TRIVIAL(debug) << "GFI sur WMS externe";
-        WebService* myWMSV = new WebService(layer->getGFIBaseUrl(), 1, 1, 10);
+        WebService* myWMS = new WebService(layer->getGFIBaseUrl(), 1, 1, 10);
         std::stringstream vectorRequest;
         std::string crsstring = crs->getRequestCode();
         if (layer->getGFIForceEPSG()) {
@@ -718,6 +719,7 @@ DataStream* Rok4Server::CommonGetFeatureInfo(std::string service, Layer* layer, 
                       << "&HEIGHT=" << height
                       << "&I=" << X
                       << "&J=" << Y
+                      << "&" << layer->getGFIExtraParams()
                       // compatibilité 1.1.1
                       << "&SRS=" << crsstring
                       << "&X=" << X
@@ -740,13 +742,13 @@ DataStream* Rok4Server::CommonGetFeatureInfo(std::string service, Layer* layer, 
         }
 
         BOOST_LOG_TRIVIAL(debug) << "REQUETE = " << vectorRequest.str();
-        RawDataStream* response = myWMSV->performRequestStream(vectorRequest.str());
+        RawDataStream* response = myWMS->performRequestStream(vectorRequest.str());
         if (response == NULL) {
-            delete myWMSV;
+            delete myWMS;
             return new SERDataStream(new ServiceException("", OWS_NOAPPLICABLE_CODE, "Internal server error", "wms"));
         }
 
-        delete myWMSV;
+        delete myWMS;
         return response;
     } else if (getFeatureInfoType.compare("SQL") == 0) {
         BOOST_LOG_TRIVIAL(debug) << "GFI sur SQL";


### PR DESCRIPTION
Possibilité de fournir des paramètres additionnels pour le getFeatureInfo avec WMS source

### [Added]

* Layer : lors de la configuration du get feature info de type EXTERNALWMS, il est possible de fournir des paramètres additionnels à ajouter à la requête vers le WMS source avec le champ "extra_query_params"