### PR TITLE
Ajout de routes OGC API Tiles

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,19 +1,31 @@
 ci-cd:
-  - .github/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/**
 
 dependencies:
-  - cmake/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - cmake/**
 
 documentation:
-  - docs/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - docs/**
 
 enhancement:
-  - src/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - src/**
 
 quality:
-  - tests/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - tests/**
 
 tooling:
-  - CMakeLists.txt
-  - config.h.in
-  - '**/CMakeLists.txt'
+- changed-files:
+  - any-glob-to-any-file:
+    - CMakeLists.txt
+    - config.h.in
+    - '**/CMakeLists.txt'

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -2,14 +2,11 @@ name: "🏷 PR Labeler"
 on:
   - pull_request
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  triage:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    - uses: actions/labeler@v5

--- a/config/layer.schema.json
+++ b/config/layer.schema.json
@@ -191,12 +191,6 @@
             "properties": {
                 "enabled": {
                     "type": "boolean"
-                },
-                "crs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         },
@@ -205,12 +199,6 @@
             "properties": {
                 "enabled": {
                     "type": "boolean"
-                },
-                "tms": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         },
@@ -228,6 +216,18 @@
                 "enabled": {
                     "type": "boolean"
                 }
+            }
+        },
+        "extra_crs": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "extra_tilematrixsets": {
+            "type": "array",
+            "items": {
+                "type": "string"
             }
         }
     },

--- a/config/services.json
+++ b/config/services.json
@@ -96,6 +96,7 @@
         "abstract": "Ce service permet la visulation de couches de données raster IGN au travers d'un flux OGC API Tiles",
         "keywords": [
             "OGC API Tiles"
-        ]
+        ],
+        "reprojection": true
     }
 }

--- a/config/services.schema.json
+++ b/config/services.schema.json
@@ -23,7 +23,7 @@
             "type": "string",
             "description": "Access conditions"
         },
-        "crs_equivalency": {
+        "crs_equivalences": {
             "type": "string",
             "description": "Path to JSON file with identical CRS (to avoid useless tranformation)"
         },
@@ -411,6 +411,11 @@
                 "metadata": {
                     "$ref": "#/$defs/metadata",
                     "description": "OGC API Tiles service's metadata"
+                },
+                "reprojection": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "OGC API Tiles reprojection activation"
                 }
             }
         }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2166,6 +2166,16 @@ components:
             - lanczos_3
             - lanczos_4
 
+        crs:
+          type: array
+          items: 
+            type: string
+
+        tms:
+          type: array
+          items: 
+            type: string
+
         get_feature_info:
           oneOf:
             - type: object
@@ -2201,20 +2211,12 @@ components:
           properties:
             pyramid:
               type: boolean
-            crs:
-              type: array
-              items: 
-                type: string
             
         wmts:
           type: object
           properties:
             pyramid:
               type: boolean
-            tms:
-              type: array
-              items: 
-                type: string
             
         tms:
           type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -858,7 +858,7 @@ paths:
         - name: f
           required: false
           in: query
-          description: format de sortie demandée
+          description: format de sortie demandé
           schema:
             type: string
             enum: ['application/json']              
@@ -926,7 +926,7 @@ paths:
         - name: f
           required: false
           in: query
-          description: format de sortie demandée
+          description: format de sortie demandé
           schema:
             type: string
             enum: ['application/json']              
@@ -946,6 +946,254 @@ paths:
                 $ref: '#/components/schemas/tiles_error'
         404:
           description: Couche inconnue
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+
+
+  /tiles/collections/{layer}/tiles:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Récupère les TMS disponibles pour une couche vecteur
+      operationId: ogc_get_vector_tilesets
+      parameters:
+
+        - name: layer
+          required: true
+          in: path
+          description: couche demandée
+          schema:
+            type: string
+
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            enum: ['application/json']              
+
+      responses:
+        200:
+          description: Couche demandée
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_tilesets'
+        400:
+          description: Format demandé invalide ou la couche demandée correspond à de la donnée raster
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+        404:
+          description: Couche inconnue
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+
+
+  /tiles/collections/{layer}/tiles/{tms}:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Récupère les niveaux disponibles pour une couche vecteur
+      operationId: ogc_get_vector_tileset
+      parameters:
+
+        - name: layer
+          required: true
+          in: path
+          description: couche demandée
+          schema:
+            type: string
+
+        - name: tms
+          required: true
+          in: path
+          description: TMS demandé
+          schema:
+            type: string
+
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            enum: ['application/json']              
+
+      responses:
+        200:
+          description: Couche demandée
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_tileset'
+        400:
+          description: Format demandé invalide ou la couche demandée correspond à de la donnée raster
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+        404:
+          description: Couche ou TMS inconnu
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+
+
+  /tiles/collections/{layer}/styles:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Récupère les styles disponibles pour une couche raster
+      operationId: ogc_get_raster_styles
+      parameters:
+
+        - name: layer
+          required: true
+          in: path
+          description: couche demandée
+          schema:
+            type: string
+
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            enum: ['application/json']              
+
+      responses:
+        200:
+          description: Couche demandée
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_styles'
+        400:
+          description: Format demandé invalide ou la couche demandée correspond à de la donnée vecteur
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+        404:
+          description: Couche inconnue
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+
+
+  /tiles/collections/{layer}/styles/{style}/map/tiles:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Récupère les TMS disponibles pour une couche raster
+      operationId: ogc_get_raster_tilesets
+      parameters:
+
+        - name: layer
+          required: true
+          in: path
+          description: couche demandée
+          schema:
+            type: string
+
+        - name: style
+          required: true
+          in: path
+          description: style demandé
+          schema:
+            type: string
+
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            enum: ['application/json']              
+
+      responses:
+        200:
+          description: Couche demandée
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_tilesets'
+        400:
+          description: Format demandé invalide ou la couche demandée correspond à de la donnée vecteur
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+        404:
+          description: Couche ou style inconnu
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+
+
+  /tiles/collections/{layer}/styles/{style}/map/tiles/{tms}:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Récupère les niveaux disponibles pour une couche raster
+      operationId: ogc_get_raster_tileset
+      parameters:
+
+        - name: layer
+          required: true
+          in: path
+          description: couche demandée
+          schema:
+            type: string
+
+        - name: style
+          required: true
+          in: path
+          description: style demandé
+          schema:
+            type: string
+
+        - name: tms
+          required: true
+          in: path
+          description: TMS demandé
+          schema:
+            type: string
+
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            enum: ['application/json']              
+
+      responses:
+        200:
+          description: Couche demandée
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_tileset'
+        400:
+          description: Format demandé invalide ou la couche demandée correspond à de la donnée vecteur
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_error'
+        404:
+          description: Couche, style ou TMS inconnu
           content:
             application/json:
               schema:
@@ -1117,66 +1365,66 @@ paths:
               schema:
                 $ref: '#/components/schemas/tiles_error'
 
-  # /tiles/tilematrixsets:
-  #   get:
-  #     tags:
-  #     - OGC API Tiles
-  #     summary: Récupère la liste des tileMatreixSet disponibles
-  #     operationId: ogc_get_tilematrixsets
-  #     parameters:
+  /tiles/tileMatrixSets:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Récupère la liste des tile matrix sets disponibles
+      operationId: ogc_get_tilematrixsets
+      parameters:
 
-  #       - name: f
-  #         required: false
-  #         in: query
-  #         description: format de sortie demandée
-  #         schema:
-  #           type: string
-  #           default:
-  #             application/json
-  #           example:
-  #             application/json
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            default:
+              application/json
+            example:
+              application/json
 
-  #     responses:
-  #       200:
-  #         description: Liste des tileMatreixSet disponibles
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: '#/components/schemas/ogc_tilematrixsets'
+      responses:
+        200:
+          description: Liste des tile matrix sets disponibles
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_tilematrixsets'
     
-  # /tiles/tilematrixsets/{tms}:
-  #   get:
-  #     tags:
-  #     - OGC API Tiles
-  #     summary: Récupère les informations sur un tileMatrixSet
-  #     operationId: ogc_get_tilematrixsets_id
-  #     parameters:
+  /tiles/tileMatrixSets/{tms}:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Récupère les informations sur un tile matrix set
+      operationId: ogc_get_tilematrixset
+      parameters:
 
-  #       - name: tms
-  #         required: true
-  #         in: path
-  #         description: tileMatrixSet demandée
-  #         schema:
-  #           type: string
+        - name: tms
+          required: true
+          in: path
+          description: tile matrix set demandé
+          schema:
+            type: string
 
-  #       - name: f
-  #         required: false
-  #         in: query
-  #         description: format de sortie demandée
-  #         schema:
-  #           type: string
-  #           default:
-  #             application/json
-  #           example:
-  #             application/json
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            default:
+              application/json
+            example:
+              application/json
   
-  #     responses:
-  #       200:
-  #         description: ...
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: '#/components/schemas/ogc_tilematrixsets_id'
+      responses:
+        200:
+          description: Définition du TMS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_tilematrixset'
 
   ######################################### ADMIN
 
@@ -1432,14 +1680,14 @@ components:
                 maxItems: 4
                 example: [-5, 40, 5, 50]
 
-    tiles_metadata:
+    tiles_link:
       type: object
       properties:
         href:
           type: string
         rel:
           type: string
-          enum: ["describedby", "self"]
+          enum: ["describedby", "self", "item"]
         type:
           type: string
         title:
@@ -1451,7 +1699,7 @@ components:
         links:
           type: array
           items:
-            $ref: '#/components/schemas/tiles_metadata'
+            $ref: '#/components/schemas/tiles_link'
         collections:
           type: array
           items:
@@ -1479,7 +1727,7 @@ components:
         links:
           type: array
           items:
-            $ref: '#/components/schemas/tiles_metadata'
+            $ref: '#/components/schemas/tiles_link'
         crs:
           type: array
           items:
@@ -1487,10 +1735,159 @@ components:
         dataType:
           type: string
           enum: ["map", "vector"]
+        mapTiles:
+          type: boolean
+        dataTiles:
+          type: boolean
         minCellSize:
           type: number
         maxCellSize:
           type: number
+
+    tiles_styles:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/tiles_link'
+        styles:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              title:
+                type: string
+              links:
+                type: array
+                items:
+                  $ref: '#/components/schemas/tiles_link'
+
+    tiles_tilesets:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/tiles_link'
+        tilesets:
+          type: array
+          items:
+            type: object
+            properties:
+              title:
+                type: string
+              dataType:
+                type: string
+                enum: ["map", "vector"]
+              crs:
+                type: string
+              tileMatrixSetURI:
+                type: string
+              links:
+                type: array
+                items:
+                  $ref: '#/components/schemas/tiles_link'
+
+    tiles_tileset:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        crs:
+          type: string
+        tileMatrixSetURI:
+          type: string
+        dataType:
+          type: string
+          enum: ["map", "vector"]
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/tiles_link'
+        tileMatrixSetLimits:
+          type: array
+          items:
+            type: object
+            properties:
+              tileMatrix:
+                type: string
+              minTileRow:
+                type: integer
+              maxTileRow:
+                type: integer
+              minTileCol:
+                type: integer
+              maxTileCol:
+                type: integer
+
+    tiles_tilematrixsets:
+      type: object
+      properties:
+        tilematrixsets:
+          type: object
+          properties:
+            id:
+              type: string
+            title:
+              type: string
+            crs:
+              type: string
+            links:
+              type: array
+              items:
+                $ref: '#/components/schemas/tiles_link'
+
+    tiles_tilematrixset:
+      type: object
+      properties:
+          id:
+            type: string
+          title:
+            type: string
+          description:
+            type: string
+          keywords:
+            type: array
+            items: 
+              type: string
+          crs:
+            type: string
+          tileMatrices:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
+                cellSize:
+                  type: number
+                cornerOfOrigin:
+                  type: string
+                  enum: ["topLeft"]
+                pointOfOrigin:
+                  type: array
+                  items:
+                    type: number
+                  minItems: 2
+                  maxItems: 2
+                tileWidth:
+                  type: integer
+                tileHeight:
+                  type: integer
+                matrixHeight:
+                  type: integer
+                matrixWidth:
+                  type: integer
+
 
     tiles_error:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -847,6 +847,51 @@ paths:
 
   ######################################### OGC API Tiles
 
+
+  /tiles:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Retourne la page d'accueil du service OGC API Tiles
+      operationId: tiles_get_landing_page
+      parameters:
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            enum: ['json']
+      responses:
+        200:
+          description: Services assurés par le service OGC API Tiles
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tiles_get_landing_page'
+
+  /tiles/conformance:
+    get:
+      tags:
+      - OGC API Tiles
+      summary: Retourne la liste des classes de conformité du service OGC API Tiles
+      operationId: tiles_get_conformance
+      parameters:
+        - name: f
+          required: false
+          in: query
+          description: format de sortie demandé
+          schema:
+            type: string
+            enum: ['json']
+      responses:
+        200:
+          description: Services assurés par le serveur
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ogc_get_conformance'
+
   /tiles/collections:
     get:
       tags:
@@ -854,14 +899,13 @@ paths:
       summary: Récupère la liste des couches disponibles
       operationId: ogc_get_collections
       parameters:
-
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            enum: ['application/json']              
+            enum: ['json']
 
         # - name: bbox
         #   required: false
@@ -922,14 +966,14 @@ paths:
           description: couche demandée
           schema:
             type: string
-
+            
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            enum: ['application/json']              
+            enum: ['json']
 
       responses:
         200:
@@ -966,14 +1010,14 @@ paths:
           description: couche demandée
           schema:
             type: string
-
+            
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            enum: ['application/json']              
+            enum: ['json']
 
       responses:
         200:
@@ -1017,14 +1061,14 @@ paths:
           description: TMS demandé
           schema:
             type: string
-
+            
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            enum: ['application/json']              
+            enum: ['json']
 
       responses:
         200:
@@ -1061,14 +1105,14 @@ paths:
           description: couche demandée
           schema:
             type: string
-
+            
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            enum: ['application/json']              
+            enum: ['json']
 
       responses:
         200:
@@ -1112,14 +1156,14 @@ paths:
           description: style demandé
           schema:
             type: string
-
+            
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            enum: ['application/json']              
+            enum: ['json']
 
       responses:
         200:
@@ -1170,14 +1214,14 @@ paths:
           description: TMS demandé
           schema:
             type: string
-
+            
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            enum: ['application/json']              
+            enum: ['json']
 
       responses:
         200:
@@ -1372,17 +1416,14 @@ paths:
       summary: Récupère la liste des tile matrix sets disponibles
       operationId: ogc_get_tilematrixsets
       parameters:
-
+            
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            default:
-              application/json
-            example:
-              application/json
+            enum: ['json']
 
       responses:
         200:
@@ -1406,17 +1447,14 @@ paths:
           description: tile matrix set demandé
           schema:
             type: string
-
+            
         - name: f
           required: false
           in: query
           description: format de sortie demandé
           schema:
             type: string
-            default:
-              application/json
-            example:
-              application/json
+            enum: ['json']
   
       responses:
         200:
@@ -1692,6 +1730,28 @@ components:
           type: string
         title:
           type: string
+
+
+    tiles_get_landing_page:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/common_metadata'
+
+    ogc_get_conformance:
+      type: object
+      properties:
+        conformsTo:
+          type: array
+          items:
+            type: string
+            format: uri
 
     tiles_collections:
       type: object

--- a/src/configurations/Layer.cpp
+++ b/src/configurations/Layer.cpp
@@ -917,7 +917,7 @@ json11::Json Layer::to_json_tiles(TilesService* service) {
     std::vector<json11::Json> links;
 
     links.push_back(json11::Json::object {
-        { "href", service->get_endpoint_uri() + "/collections/" + id + "?f=application/json"},
+        { "href", service->get_endpoint_uri() + "/collections/" + id + "?f=json"},
         { "rel", "self"},
         { "type", "application/json"},
         { "title", "this document"}
@@ -929,14 +929,14 @@ json11::Json Layer::to_json_tiles(TilesService* service) {
 
     if (Rok4Format::is_raster(pyramid->get_format())) {
         links.push_back(json11::Json::object {
-            { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles?f=application/json"},
+            { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles?f=json"},
             { "rel", "describedby"},
             { "type", "application/json"},
             { "title", "Styles list for " + id}
         });
     } else {
         links.push_back(json11::Json::object {
-            { "href", service->get_endpoint_uri() + "/collections/" + id + "/tiles?f=application/json"},
+            { "href", service->get_endpoint_uri() + "/collections/" + id + "/tiles?f=json"},
             { "rel", "describedby"},
             { "type", "application/json"},
             { "title", "Tilesets list for " + id}
@@ -977,7 +977,7 @@ json11::Json Layer::to_json_styles(TilesService* service) {
         { "title", title },
         { "links", json11::Json::array {
             json11::Json::object {
-                { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles?f=application/json"},
+                { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles?f=json"},
                 { "rel", "self"},
                 { "type", "application/json"},
                 { "title", "this document"}
@@ -992,7 +992,7 @@ json11::Json Layer::to_json_styles(TilesService* service) {
             { "title", s->get_titles().at(0)},
             { "links", json11::Json::array {
                 json11::Json::object {
-                    { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles/" + s->get_identifier() + "/map/tiles?f=application/json"},
+                    { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles/" + s->get_identifier() + "/map/tiles?f=json"},
                     { "rel", "describedby"},
                     { "type", "application/json"},
                     { "title", "Tilesets list for " + id + " with style " + s->get_identifier()}
@@ -1015,7 +1015,7 @@ json11::Json Layer::to_json_tilesets(TilesService* service, Style* style) {
     if (style == NULL) {
         // Interrogation de donnée vecteur
         links.push_back(json11::Json::object {
-            { "href", service->get_endpoint_uri() + "/collections/" + id + "/tiles?f=application/json"},
+            { "href", service->get_endpoint_uri() + "/collections/" + id + "/tiles?f=json"},
             { "rel", "self"},
             { "type", "application/json"},
             { "title", "this document"}
@@ -1023,7 +1023,7 @@ json11::Json Layer::to_json_tilesets(TilesService* service, Style* style) {
     } else {
         // Interrogation de donnée raster
         links.push_back(json11::Json::object {
-            { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles/" + style->get_identifier() + "/map/tiles?f=application/json"},
+            { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles/" + style->get_identifier() + "/map/tiles?f=json"},
             { "rel", "self"},
             { "type", "application/json"},
             { "title", "this document"}
@@ -1040,17 +1040,17 @@ json11::Json Layer::to_json_tilesets(TilesService* service, Style* style) {
 
         if (style == NULL) {
             data_type = "vector";
-            tileset_uri = service->get_endpoint_uri() + "/collections/" + id + "/tiles/" + t->tms->get_id() + "?f=application/json";
+            tileset_uri = service->get_endpoint_uri() + "/collections/" + id + "/tiles/" + t->tms->get_id() + "?f=json";
         } else {
             data_type = "map";
-            tileset_uri = service->get_endpoint_uri() + "/collections/" + id + "/styles/" + style->get_identifier() + "/map/tiles/" + t->tms->get_id() + "?f=application/json";
+            tileset_uri = service->get_endpoint_uri() + "/collections/" + id + "/styles/" + style->get_identifier() + "/map/tiles/" + t->tms->get_id() + "?f=json";
         }
 
         tilesets.push_back(json11::Json::object {
             { "title", title },
             { "dataType", data_type},
             { "crs", t->tms->get_crs()->get_url()},
-            { "tileMatrixSetURI", service->get_endpoint_uri() + "/tileMatrixSets/" + t->tms->get_id() + "?f=application/json"},
+            { "tileMatrixSetURI", service->get_endpoint_uri() + "/tileMatrixSets/" + t->tms->get_id() + "?f=json"},
             { "links", json11::Json::array {
                 json11::Json::object {
                     { "href", tileset_uri},
@@ -1078,7 +1078,7 @@ json11::Json Layer::to_json_tileset(TilesService* service, Style* style, TileMat
         { "title", title},
         { "description", abstract},
         { "crs", tmsi->tms->get_crs()->get_url()},
-        { "tileMatrixSetURI", service->get_endpoint_uri() + "/tileMatrixSets/" + tmsi->tms->get_id() + "?f=application/json"},
+        { "tileMatrixSetURI", service->get_endpoint_uri() + "/tileMatrixSets/" + tmsi->tms->get_id() + "?f=json"},
     };
 
     std::vector<json11::Json> links;
@@ -1087,7 +1087,7 @@ json11::Json Layer::to_json_tileset(TilesService* service, Style* style, TileMat
         // Interrogation de donnée vecteur
         res["dataType"] = "vector";
         links.push_back(json11::Json::object {
-            { "href", service->get_endpoint_uri() + "/collections/" + id + "/tiles/" + tmsi->tms->get_id() + "?f=application/json"},
+            { "href", service->get_endpoint_uri() + "/collections/" + id + "/tiles/" + tmsi->tms->get_id() + "?f=json"},
             { "rel", "self"},
             { "type", "application/json"},
             { "title", "this document"}
@@ -1104,7 +1104,7 @@ json11::Json Layer::to_json_tileset(TilesService* service, Style* style, TileMat
         // Interrogation de donnée raster
         res["dataType"] = "map";
         links.push_back(json11::Json::object {
-            { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles/" + style->get_identifier() + "/map/tiles/" + tmsi->tms->get_id() + "?f=application/json"},
+            { "href", service->get_endpoint_uri() + "/collections/" + id + "/styles/" + style->get_identifier() + "/map/tiles/" + tmsi->tms->get_id() + "?f=json"},
             { "rel", "self"},
             { "type", "application/json"},
             { "title", "this document"}

--- a/src/configurations/Services.cpp
+++ b/src/configurations/Services.cpp
@@ -291,7 +291,7 @@ std::vector<CRS*> ServicesConfiguration::get_equals_crs(std::string crs)
 
 bool ServicesConfiguration::are_crs_equals( std::string crs1, std::string crs2 ) {
 
-    if (crs1 == crs2) {
+    if (to_upper_case(crs1) == to_upper_case(crs2)) {
         return true;
     }
 
@@ -322,13 +322,6 @@ ServicesConfiguration::~ServicesConfiguration(){
     delete admin_service;
     delete tiles_service;
     delete contact;
-
-    // Les CRS équivalents
-    std::map<std::string, std::vector<CRS*> >::iterator it;
-    for ( it = crs_equivalences.begin(); it != crs_equivalences.end(); it++ )
-        for (unsigned int i = 0 ; i < it->second.size() ; i++) {
-            delete it->second.at(i);
-        }
 }
 
 void ServicesConfiguration::clean_cache() {

--- a/src/services/admin/layers.cpp
+++ b/src/services/admin/layers.cpp
@@ -50,12 +50,11 @@
 
 DataStream* AdminService::add_layer ( Request* req, Rok4Server* serv ) {
 
-
     std::string str_layer = req->path_params.at(0);
 
     Layer* layer = serv->get_server_configuration()->get_layer(str_layer);
 
-    if ( layer != NULL ) throw AdminException::get_error_message("Layer " + str_layer +" already exists.", "Configuration conflict", 409);
+    if ( layer != NULL ) throw AdminException::get_error_message("Layer already exists.", "Configuration conflict", 409);
 
     layer = new Layer( str_layer, req->body, serv->get_services_configuration() );
     if ( ! layer->is_ok() ) {
@@ -73,6 +72,10 @@ DataStream* AdminService::add_layer ( Request* req, Rok4Server* serv ) {
 DataStream* AdminService::update_layer ( Request* req, Rok4Server* serv ) {
 
     std::string str_layer = req->path_params.at(0);
+    if ( contain_chars(str_layer, "\"")) {
+        BOOST_LOG_TRIVIAL(warning) <<  "Forbidden char detected in TILES layer: " << str_layer ;
+        throw AdminException::get_error_message("Layer does not exists.", "Not found", 404);
+    }
 
     Layer* layer = serv->get_server_configuration()->get_layer(str_layer);
 
@@ -96,6 +99,10 @@ DataStream* AdminService::update_layer ( Request* req, Rok4Server* serv ) {
 DataStream* AdminService::delete_layer ( Request* req, Rok4Server* serv ) {
 
     std::string str_layer = req->path_params.at(0);
+    if ( contain_chars(str_layer, "\"")) {
+        BOOST_LOG_TRIVIAL(warning) <<  "Forbidden char detected in TILES layer: " << str_layer ;
+        throw AdminException::get_error_message("Layer does not exists.", "Not found", 404);
+    }
 
     Layer* layer = serv->get_server_configuration()->get_layer(str_layer);
 

--- a/src/services/common/getcapabilities.cpp
+++ b/src/services/common/getcapabilities.cpp
@@ -52,7 +52,7 @@
 DataStream* CommonService::get_landing_page ( Request* req, Rok4Server* serv ) {
 
     std::string f = req->get_query_param("f");
-    if (f != "" && f != "application/json") {
+    if (f != "" && f != "application/json" && f != "json") {
         throw CommonException::get_error_message("InvalidParameter", "Format unknown", 400);
     }
 
@@ -100,7 +100,7 @@ DataStream* CommonService::get_landing_page ( Request* req, Rok4Server* serv ) {
 
     if (services->get_tiles_service()->is_enabled()) {
         links.push_back(json11::Json::object {
-            { "href", services->get_tiles_service()->get_endpoint_uri() + "/collections?f=application/json"},
+            { "href", services->get_tiles_service()->get_endpoint_uri() + "/collections?f=json"},
             { "rel", "data"},
             { "type", "application/json"},
             { "title", "OGC API Tiles capabilities"}

--- a/src/services/tiles/Service.cpp
+++ b/src/services/tiles/Service.cpp
@@ -133,7 +133,15 @@ TilesService::TilesService (json11::Json& doc) : Service(doc), metadata(NULL) {
 DataStream* TilesService::process_request(Request* req, Rok4Server* serv) {
     BOOST_LOG_TRIVIAL(debug) << "TILES service";
 
-    if ( match_route( "/collections", {"GET"}, req ) ) {
+    if ( match_route( "", {"GET"}, req ) ) {
+        BOOST_LOG_TRIVIAL(debug) << "GETLANDINGPAGE request";
+        return get_landing_page(req, serv);
+    }
+    else if ( match_route( "/conformance", {"GET"}, req ) ) {
+        BOOST_LOG_TRIVIAL(debug) << "GETCONFORMANCE request";
+        return get_conformance(req, serv);
+    }
+    else if ( match_route( "/collections", {"GET"}, req ) ) {
         BOOST_LOG_TRIVIAL(debug) << "GETCAPABILITIES request";
         return get_capabilities(req, serv);
     }

--- a/src/services/tiles/Service.h
+++ b/src/services/tiles/Service.h
@@ -64,11 +64,17 @@ private:
      * \todo Filtrer selon la bbox
      */
     DataStream* get_capabilities ( Request* req, Rok4Server* serv );
+    DataStream* get_tilematrixsets ( Request* req, Rok4Server* serv );
+    DataStream* get_tilematrixset ( Request* req, Rok4Server* serv );
     DataStream* get_tiles ( Request* req, Rok4Server* serv );
     DataStream* get_feature_info ( Request* req, Rok4Server* serv );
+    DataStream* get_styles ( Request* req, Rok4Server* serv);
+    DataStream* get_tilesets ( Request* req, Rok4Server* serv, bool is_map_request );
+    DataStream* get_tileset ( Request* req, Rok4Server* serv, bool is_map_request );
     DataStream* get_tile ( Request* req, Rok4Server* serv, bool is_map_request );
 
     Metadata* metadata;
+    bool reprojection;
 
     std::string cache_getcapabilities;
 
@@ -93,6 +99,16 @@ public:
         cache_mtx.lock();
         cache_getcapabilities.clear();
         cache_mtx.unlock();
+    };
+
+    /**
+     * \~french
+     * \brief La reprojection est-elle activée
+     * \~english
+     * \brief Is reprojection enabled
+     */
+    bool reprojection_enabled() {
+        return reprojection;
     };
 
     /**

--- a/src/services/tiles/Service.h
+++ b/src/services/tiles/Service.h
@@ -59,6 +59,8 @@ class TilesService : public Service {
 
 private:
 
+    DataStream* get_conformance ( Request* req, Rok4Server* serv );
+    DataStream* get_landing_page ( Request* req, Rok4Server* serv );
     /**
      * \todo Gérer la pagination
      * \todo Filtrer selon la bbox

--- a/src/services/tiles/getcapabilities.cpp
+++ b/src/services/tiles/getcapabilities.cpp
@@ -49,10 +49,76 @@
 #include "services/tiles/Service.h"
 #include "Rok4Server.h"
 
+
+DataStream* TilesService::get_landing_page ( Request* req, Rok4Server* serv ) {
+    std::string f = req->get_query_param("f");
+    if (f != "" && f != "application/json" && f != "json") {
+        throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
+    }
+
+    std::vector<json11::Json> links;
+
+    links.push_back(json11::Json::object {
+        { "href", endpoint_uri},
+        { "rel", "self"},
+        { "type", "application/json"},
+        { "title", "this document"}
+    });
+
+    links.push_back(json11::Json::object {
+        { "href", endpoint_uri + "/collections?f=json"},
+        { "rel", "data"},
+        { "type", "application/json"},
+        { "title", "Information about the collections"}
+    });
+
+    links.push_back(json11::Json::object {
+        { "href", endpoint_uri + "/conformance?f=json"},
+        { "rel", "data"},
+        { "type", "application/json"},
+        { "title", "OGC API conformance classes implemented by this service"}
+    });
+
+    json11::Json::object res = json11::Json::object {
+        { "title", title },
+        { "description", abstract },
+        { "links", links }
+    };
+
+    return new MessageDataStream ( json11::Json{ res }.dump(), "application/json", 200 );
+}
+
+DataStream* TilesService::get_conformance ( Request* req, Rok4Server* serv ) {
+    std::string f = req->get_query_param("f");
+    if (f != "" && f != "application/json" && f != "json") {
+        throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
+    }
+
+    json11::Json::object res = json11::Json::object {
+        { "conformsTo", json11::Json::array{
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json",
+            "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+            "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/geodata-tilesets",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/dataset-tilesets",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/jpeg",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/png",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt",
+            "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tiff"
+        } }
+    };
+
+    return new MessageDataStream ( json11::Json{ res }.dump(), "application/json", 200 );
+}
+
 DataStream* TilesService::get_capabilities ( Request* req, Rok4Server* serv ) {
 
     std::string f = req->get_query_param("f");
-    if (f != "" && f != "application/json") {
+    if (f != "" && f != "application/json" && f != "json") {
         throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
     }
 
@@ -62,7 +128,7 @@ DataStream* TilesService::get_capabilities ( Request* req, Rok4Server* serv ) {
 
     std::vector<json11::Json> links;
     links.push_back(json11::Json::object {
-        { "href", endpoint_uri + "/collections?f=application/json"},
+        { "href", endpoint_uri + "/collections?f=json"},
         { "rel", "self"},
         { "type", "application/json"},
         { "title", "this document"}
@@ -98,7 +164,7 @@ DataStream* TilesService::get_capabilities ( Request* req, Rok4Server* serv ) {
 DataStream* TilesService::get_tiles ( Request* req, Rok4Server* serv ) {
 
     std::string f = req->get_query_param("f");
-    if (f != "" && f != "application/json") {
+    if (f != "" && f != "application/json" && f != "json") {
         throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
     }
 
@@ -120,7 +186,7 @@ DataStream* TilesService::get_tiles ( Request* req, Rok4Server* serv ) {
 DataStream* TilesService::get_styles ( Request* req, Rok4Server* serv ) {
 
     std::string f = req->get_query_param("f");
-    if (f != "" && f != "application/json") {
+    if (f != "" && f != "application/json" && f != "json") {
         throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
     }
 
@@ -147,7 +213,7 @@ DataStream* TilesService::get_styles ( Request* req, Rok4Server* serv ) {
 DataStream* TilesService::get_tilesets ( Request* req, Rok4Server* serv, bool is_map_request ) {
 
     std::string f = req->get_query_param("f");
-    if (f != "" && f != "application/json") {
+    if (f != "" && f != "application/json" && f != "json") {
         throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
     }
     
@@ -201,7 +267,7 @@ DataStream* TilesService::get_tilesets ( Request* req, Rok4Server* serv, bool is
 DataStream* TilesService::get_tileset ( Request* req, Rok4Server* serv, bool is_map_request ) {
 
     std::string f = req->get_query_param("f");
-    if (f != "" && f != "application/json") {
+    if (f != "" && f != "application/json" && f != "json") {
         throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
     }
 

--- a/src/services/tiles/tilematrixsets.cpp
+++ b/src/services/tiles/tilematrixsets.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright © (2011-2013) Institut national de l'information
+ *                    géographique et forestière
+ *
+ * Géoportail SAV <contact.geoservices@ign.fr>
+ *
+ * This software is a computer program whose purpose is to publish geographic
+ * data using OGC WMS and WMTS protocol.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ *
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+/**
+ * \file services/tiles/getcapabilities.cpp
+ ** \~french
+ * \brief Implémentation de la classe TilesService
+ ** \~english
+ * \brief Implements classe TilesService
+ */
+
+#include <iostream>
+
+#include "services/tiles/Exception.h"
+#include "services/tiles/Service.h"
+#include "Rok4Server.h"
+
+DataStream* TilesService::get_tilematrixsets ( Request* req, Rok4Server* serv ) {
+
+    std::string f = req->get_query_param("f");
+    if (f != "" && f != "application/json") {
+        throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
+    }
+
+    json11::Json::object res = json11::Json::object {};
+
+    std::vector<json11::Json::object> tmss;
+    
+    for(auto const& t: TmsBook::get_book()) {
+        tmss.push_back(json11::Json::object {
+            { "id", t.second->get_id()},
+            { "title", t.second->get_title()},
+            { "crs", t.second->get_crs()->get_url()},
+            { "links", json11::Json::array {
+                json11::Json::object {
+                    { "href", endpoint_uri + "/tileMatrixSets/" + t.second->get_id() + "?f=application/json"},
+                    { "rel", "describedby"},
+                    { "type", "application/json"},
+                    { "title", t.second->get_id() + " definition as application/json"}
+                }
+            }}
+        });
+    }
+
+    res["tileMatrixSets"] = tmss;
+
+    return new MessageDataStream ( json11::Json{ res }.dump(), "application/json", 200 );
+}
+
+
+DataStream* TilesService::get_tilematrixset ( Request* req, Rok4Server* serv ) {
+
+    std::string f = req->get_query_param("f");
+    if (f != "" && f != "application/json") {
+        throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
+    }
+
+    // Le TMS
+    std::string str_tms = req->path_params.at(0);
+    if ( contain_chars(str_tms, "\"")) {
+        BOOST_LOG_TRIVIAL(warning) <<  "Forbidden char detected in TILES tms: " << str_tms ;
+        throw TilesException::get_error_message("ResourceNotFound", "Tile matrix set unknown", 404);
+    }
+
+    TileMatrixSet* tms = TmsBook::get_tms(str_tms);
+    if ( tms == NULL) {
+        throw TilesException::get_error_message("ResourceNotFound", "Tile matrix set "+str_tms+" unknown", 404);
+    }
+
+    json11::Json::object res = json11::Json::object {
+        { "id", tms->get_id()},
+        { "title", tms->get_title()},
+        { "description", tms->get_abstract()},
+        { "keywords", *(tms->get_keywords())},
+        { "crs", tms->get_crs()->get_url()},
+    };
+
+    std::vector<json11::Json> tile_matrices;
+    
+    for(TileMatrix* tm: tms->get_ordered_tm(false)) {
+        tile_matrices.push_back(json11::Json::object {
+            { "id", tm->get_id()},
+            { "cellSize", tm->get_res()},
+            { "cornerOfOrigin", "topLeft"},
+            { "pointOfOrigin", json11::Json::array{ tm->get_x0(), tm->get_y0()}},
+            { "tileWidth", tm->get_tile_width()},
+            { "tileHeight", tm->get_tile_height()},
+            { "matrixHeight", int(tm->get_matrix_width())},
+            { "matrixWidth", int(tm->get_matrix_height())}
+        });
+    }
+
+    res["tileMatrices"] = tile_matrices;
+
+    return new MessageDataStream ( json11::Json{ res }.dump(), "application/json", 200 );
+}
+

--- a/src/services/tiles/tilematrixsets.cpp
+++ b/src/services/tiles/tilematrixsets.cpp
@@ -52,7 +52,7 @@
 DataStream* TilesService::get_tilematrixsets ( Request* req, Rok4Server* serv ) {
 
     std::string f = req->get_query_param("f");
-    if (f != "" && f != "application/json") {
+    if (f != "" && f != "application/json" && f != "json") {
         throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
     }
 
@@ -67,7 +67,7 @@ DataStream* TilesService::get_tilematrixsets ( Request* req, Rok4Server* serv ) 
             { "crs", t.second->get_crs()->get_url()},
             { "links", json11::Json::array {
                 json11::Json::object {
-                    { "href", endpoint_uri + "/tileMatrixSets/" + t.second->get_id() + "?f=application/json"},
+                    { "href", endpoint_uri + "/tileMatrixSets/" + t.second->get_id() + "?f=json"},
                     { "rel", "describedby"},
                     { "type", "application/json"},
                     { "title", t.second->get_id() + " definition as application/json"}
@@ -85,7 +85,7 @@ DataStream* TilesService::get_tilematrixsets ( Request* req, Rok4Server* serv ) 
 DataStream* TilesService::get_tilematrixset ( Request* req, Rok4Server* serv ) {
 
     std::string f = req->get_query_param("f");
-    if (f != "" && f != "application/json") {
+    if (f != "" && f != "application/json" && f != "json") {
         throw TilesException::get_error_message("InvalidParameter", "Format unknown", 400);
     }
 

--- a/src/services/wms/Service.cpp
+++ b/src/services/wms/Service.cpp
@@ -394,6 +394,9 @@ bool WmsService::is_available_crs(CRS* c) {
     return is_available_crs(c->get_request_code());
 }
 bool WmsService::is_available_crs(std::string c) {
+    if (! reprojection) {
+        return false;
+    }
     for ( unsigned int k = 0; k < crss.size(); k++ ) {
         if ( crss.at (k)->cmp_request_code ( c ) ) {
             return true;

--- a/src/services/wms/getcapabilities.cpp
+++ b/src/services/wms/getcapabilities.cpp
@@ -67,10 +67,6 @@ DataStream* WmsService::get_capabilities ( Request* req, Rok4Server* serv ) {
 
     ServicesConfiguration* services = serv->get_services_configuration();
 
-    // On va mémoriser les TMS utilisés, avec les niveaux du haut et du bas
-    // La clé est un triplet : nom du TMS, niveau du haut, niveau du bas
-    std::map< std::string, WmtsTmsInfos> used_tms_list;
-
     ptree tree;
 
     ptree& root = tree.add("WMS_Capabilities", "");

--- a/src/services/wms/getfeatureinfo.cpp
+++ b/src/services/wms/getfeatureinfo.cpp
@@ -159,7 +159,7 @@ DataStream* WmsService::get_feature_info ( Request* req, Rok4Server* serv ) {
     if (! is_available_crs(str_crs) ) {
         for ( unsigned int i = 0; i < layers.size() ; i++ ) {
             bool crs_equals = serv->get_services_configuration()->are_crs_equals(crs->get_request_code(), layers.at(i)->get_pyramid()->get_tms()->get_crs()->get_request_code());
-            if (! crs_equals && ! layers.at ( i )->is_available_crs_wms(str_crs) )
+            if (! crs_equals && ! layers.at ( i )->is_available_crs(str_crs) )
                 throw WmsException::get_error_message("CRS is not available for the layer " + layers.at ( i )->get_id(), "InvalidParameterValue", 400);
         }
     }

--- a/src/services/wms/getmap.cpp
+++ b/src/services/wms/getmap.cpp
@@ -135,8 +135,9 @@ DataStream* WmsService::get_map ( Request* req, Rok4Server* serv ) {
     if (! is_available_crs(str_crs) ) {
         for ( unsigned int i = 0; i < layers.size() ; i++ ) {
             bool crs_equals = serv->get_services_configuration()->are_crs_equals(crs->get_request_code(), layers.at(i)->get_pyramid()->get_tms()->get_crs()->get_request_code());
-            if (! crs_equals && ! layers.at ( i )->is_available_crs_wms(str_crs) )
+            if (! crs_equals && (! reprojection || ! layers.at ( i )->is_available_crs(str_crs)) ) {
                 throw WmsException::get_error_message("CRS is not available for the layer " + layers.at ( i )->get_id(), "InvalidParameterValue", 400);
+            }
         }
     }
 

--- a/src/services/wmts/gettile.cpp
+++ b/src/services/wmts/gettile.cpp
@@ -278,8 +278,7 @@ DataStream* WmtsService::get_tile(Request* req, Rok4Server* serv) {
                 return new AscEncoder(image);
             }
         }
-    } else {
-        // TMS d'interrogation à la demande mais reprojection non activée
-        throw WmtsException::get_error_message("Tile matrix set " + str_tms + " unknown", "InvalidParameterValue", 400);
     }
+    // TMS d'interrogation à la demande mais reprojection non activée
+    throw WmtsException::get_error_message("Tile matrix set " + str_tms + " unknown", "InvalidParameterValue", 400);
 }


### PR DESCRIPTION
### [Added]

* OGC API Tiles :
    * ajout des routes de découvertes pour connaître les éventuels styles, TMS et tuiles limites pour les couches
    * ajout des routes de lecture des TMS
    * ajout d'une route de découverte de ce service
    * ajout de la route de conformité aux classes
    * 
### [Changed]

* Les CRS et TMS additionnels dans le descripteur de couche sont à la racine pour pouvoir être exploités dans plusieurs services