### PR TITLE
Gestion d'un style par défaut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.1.2
+
+### [Added]
+
+* `Layer` : rétablissement d'un style par défaut au chargement de la couche. L'identifiant de ce style par défaut peut être fourni via le champ `default_style` dans le fichier de configuration des services, à la racine (optionnel, `normal` par défaut)
+
 ## 6.1.1
 
 ### [Fixed]

--- a/config/services.json
+++ b/config/services.json
@@ -17,6 +17,7 @@
         "email": ""
     },
     "crs_equivalences": "/etc/rok4/equals_crs.json",
+    "default_style": "normal",
     "admin": {
         "enabled": true
     },

--- a/config/services.schema.json
+++ b/config/services.schema.json
@@ -27,6 +27,11 @@
             "type": "string",
             "description": "Path to JSON file with identical CRS (to avoid useless tranformation)"
         },
+        "default_style": {
+            "type": "string",
+            "description": "Default style internal identifier",
+            "default": "normal"
+        },
         "contact": {
             "type": "object",
             "additionalProperties": false,

--- a/src/configurations/Layer.cpp
+++ b/src/configurations/Layer.cpp
@@ -348,8 +348,16 @@ bool Layer::parse(json11::Json& doc, ServicesConfiguration* services) {
         }
 
         if ( available_styles.size() == 0 ) {
-            error_message =  "No provided valid style, the layer is not valid"  ;
-            return false;
+            Style* sty = StyleBook::get_style(services->get_default_style_id());
+            if ( sty == NULL ) {
+                error_message =  "No valid style (even the default one), the layer is not valid"  ;
+                return false;
+            }
+            if ( ! is_style_handled(sty) ) {
+                error_message =  "No valid style (even the default one), the layer is not valid"  ;
+                return false;
+            }
+            available_styles.push_back ( sty );
         }
 
         // Configuration des reprojections possibles

--- a/src/configurations/Metadata.h
+++ b/src/configurations/Metadata.h
@@ -179,7 +179,7 @@ public:
     void add_node_tms(ptree& parent) {
         ptree& node = parent.add("Metadata", "");
         node.add("<xmlattr>.type", type);
-        node.add("<xmlattr>.mime-type", "text/xml");
+        node.add("<xmlattr>.mime-type", format);
         node.add("<xmlattr>.href", href);
     }
 

--- a/src/configurations/Services.cpp
+++ b/src/configurations/Services.cpp
@@ -49,6 +49,7 @@ bool ServicesConfiguration::parse(json11::Json& doc) {
     fee="";
     access_constraint="";
     provider_site="";
+    default_style="normal";
 
     // ----------------------- Global 
 
@@ -87,6 +88,13 @@ bool ServicesConfiguration::parse(json11::Json& doc) {
         }
     } else if (! doc["crs_equivalences"].is_null()) {
         error_message = "crs_equivalences have to be a string";
+        return false;
+    }
+
+    if (doc["default_style"].is_string()) {
+        default_style = doc["default_style"].string_value();
+    } else if (! doc["default_style"].is_null()) {
+        error_message = "default_style have to be a string";
         return false;
     }
 
@@ -311,6 +319,10 @@ bool ServicesConfiguration::are_crs_equals( std::string crs1, std::string crs2 )
     }
 
     return false;
+}
+
+std::string ServicesConfiguration::get_default_style_id() {
+    return default_style;
 }
 
 ServicesConfiguration::~ServicesConfiguration(){ 

--- a/src/configurations/Services.h
+++ b/src/configurations/Services.h
@@ -103,6 +103,8 @@ class ServicesConfiguration : public Configuration
         };
         bool are_crs_equals( std::string crs1, std::string crs2 );
 
+        std::string get_default_style_id();
+
         /**
          * \~french
          * \brief Supprime les réponses cachées
@@ -121,6 +123,8 @@ class ServicesConfiguration : public Configuration
         std::string access_constraint;
 
         Contact* contact;
+
+        std::string default_style;
 
     private:
 


### PR DESCRIPTION
### [Added]

* `Layer` : rétablissement d'un style par défaut au chargement de la couche. L'identifiant de ce style par défaut peut être fourni via le champ `default_style` dans le fichier de configuration des services, à la racine (optionnel, `normal` par défaut)