### PR TITLE
Release 6.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 6.1.3
+
+### [Fixed]
+
+* `WMTS` : 
+  * correction du calcul des tuiles limites pour le TMS natif lorsque les limites de la couche sont surchargées par une bbox
+  * pour que la couche apparaisse dans les capacités Inspire, le format de la tuile doit être le PNG
+  * dans les capacités inspire, `inspire_vs:ExtendedCapabilities` doit être dans `OperationsMetadata`
+* `WMS`
+  * Ajout des schémas XML dans les réponses en erreur
+
 ## 6.1.2
 
 ### [Added]

--- a/src/Inspire.cpp
+++ b/src/Inspire.cpp
@@ -147,6 +147,11 @@ bool is_inspire_wmts ( Layer* layer ) {
         return false;
     }
 
+    if (Rok4Format::to_mime_type ( layer->get_pyramid()->get_format() ) != "image/png") {
+        BOOST_LOG_TRIVIAL(debug) << "Non conforme INSPIRE WMTS (" << layer->get_id() << ") : données pas en png" ;
+        return false;
+    }
+
     // Pour être inspire, le style par défaut doit avoir le bon identifiant
     if (layer->get_default_style()->get_identifier() != "inspire_common:DEFAULT") {
         BOOST_LOG_TRIVIAL(debug) << "Non conforme INSPIRE WMTS (" << layer->get_id() << ") : style par défaut != inspire_common:DEFAULT" ;

--- a/src/configurations/Layer.cpp
+++ b/src/configurations/Layer.cpp
@@ -217,20 +217,6 @@ bool Layer::parse(json11::Json& doc, ServicesConfiguration* services) {
         return false;
     }
 
-    // On a forcément le TMS natif de la donnée pour le WMTS
-    TileMatrixSetInfos* infos_tms_natif = new TileMatrixSetInfos(pyramid->get_tms());
-
-    infos_tms_natif->set_bottom_top(pyramid->get_lowest_level()->get_id(), pyramid->get_highest_level()->get_id());
-
-    for (Level* l : pyramid->get_ordered_levels(false)) {
-        infos_tms_natif->limits.push_back(l->get_tile_limits());
-    }
-
-    available_tilematrixsets.push_back(infos_tms_natif);
-
-    // On a forcément le CRS natif de la donnée pour le WMS
-    available_crss.push_back ( pyramid->get_tms()->get_crs() );
-
     /********************** Gestion de l'étendue des données */
 
     if (doc["bbox"].is_object()) {
@@ -254,6 +240,20 @@ bool Layer::parse(json11::Json& doc, ServicesConfiguration* services) {
         /* Calcul de la bbox dans la projection des données, à partir des tuiles limites des niveaux de la pyramide */
         calculate_bboxes();
     }
+
+    // On a forcément le TMS natif de la donnée pour le WMTS
+    TileMatrixSetInfos* infos_tms_natif = new TileMatrixSetInfos(pyramid->get_tms());
+
+    infos_tms_natif->set_bottom_top(pyramid->get_lowest_level()->get_id(), pyramid->get_highest_level()->get_id());
+
+    for (Level* l : pyramid->get_ordered_levels(false)) {
+        infos_tms_natif->limits.push_back(l->get_tile_limits());
+    }
+
+    available_tilematrixsets.push_back(infos_tms_natif);
+
+    // On a forcément le CRS natif de la donnée pour le WMS
+    available_crss.push_back ( pyramid->get_tms()->get_crs() );
 
 
     // Services autorisés a priori

--- a/src/services/wms/Exception.cpp
+++ b/src/services/wms/Exception.cpp
@@ -45,7 +45,7 @@
 
 #include "services/wms/Exception.h"
 
-std::string WmsException::xml_template = "<ServiceExceptionReport><ServiceException code=\"%s\">%s</ServiceException></ServiceExceptionReport>";
+std::string WmsException::xml_template = "<ServiceExceptionReport version=\"1.3.0\" xmlns=\"http://www.opengis.net/ogc\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/ogc http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd\"><ServiceException code=\"%s\">%s</ServiceException></ServiceExceptionReport>";
 
 MessageDataStream* WmsException::get_error_message(std::string reason, std::string code, int status) {
     return new MessageDataStream(str(boost::format(xml_template) % code % reason), "text/xml", status);

--- a/src/services/wmts/getcapabilities.cpp
+++ b/src/services/wmts/getcapabilities.cpp
@@ -134,7 +134,7 @@ DataStream* WmtsService::get_capabilities ( Request* req, Rok4Server* serv ) {
     op_getfeatureinfo.add("ows:DCP.ows:HTTP.ows:Get.ows:Constraint.ows:AllowedValues.ows:Value", "KVP");
 
     if (req->is_inspire(default_inspire)) {
-        ptree& inspire_extension = root.add("inspire_vs:ExtendedCapabilities", "");
+        ptree& inspire_extension = root.add("ows:OperationsMetadata.inspire_vs:ExtendedCapabilities", "");
 
         if (metadata) {
             inspire_extension.add("inspire_common:MetadataUrl.inspire_common:URL", metadata->get_href());


### PR DESCRIPTION
### [Fixed]

* `WMTS` :
  * correction du calcul des tuiles limites pour le TMS natif lorsque les limites de la couche sont surchargées par une bbox
  * pour que la couche apparaisse dans les capacités Inspire, le format de la tuile doit être le PNG
  * dans les capacités inspire, `inspire_vs:ExtendedCapabilities` doit être dans `OperationsMetadata`
* `WMS`
  * Ajout des schémas XML dans les réponses en erreur