### PR TITLE
Corrections de la diffusion des tuiles bil compressées et GeoTIFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 6.1.4
+
+### [Fixed]
+
+* `WMS`
+  * Correction de l'attribution dans les capacités : contenu du logo et ordre des balises
+  * Correction du géoréférencement dans les réponses GeoTIFF
+
+* `TMS`
+  * Correction de l'attribution dans les capacités : contenu du logo
+  * Ajout du header `Content-Encoding: defalte` pour les tuiles bil compressées
+
+* `WMTS`
+  * Correction des balises de métadonnées dans les capacités
+  * Ajout du header `Content-Encoding: defalte` pour les tuiles bil compressées
+
 ## 6.1.3
 
 ### [Fixed]

--- a/src/configurations/Attribution.h
+++ b/src/configurations/Attribution.h
@@ -137,13 +137,14 @@ public:
      */
     void add_node_tms(ptree& parent) {
         ptree& node = parent.add("Attribution", "");
+        node.add("<xmlattr>.href", href);
         node.add("Title", title);
 
         if (logo != NULL) {
             node.add("Logo.<xmlattr>.width", width);
             node.add("Logo.<xmlattr>.height", height);
-            node.add("Logo.<xmlattr>.href", href);
-            node.add("Logo.<xmlattr>.mime-type", format);
+            node.add("Logo.<xmlattr>.href", logo->get_href());
+            node.add("Logo.<xmlattr>.mime-type", logo->get_format());
         }
     }
 
@@ -162,9 +163,9 @@ public:
         if (logo != NULL) {
             node.add("LogoURL.<xmlattr>.width", width);
             node.add("LogoURL.<xmlattr>.height", height);
-            node.add("LogoURL.OnlineResource.<xmlattr>.xlink:href", href);
+            node.add("LogoURL.Format", logo->get_format());
+            node.add("LogoURL.OnlineResource.<xmlattr>.xlink:href", logo->get_href());
             node.add("LogoURL.OnlineResource.<xmlattr>.xlink:type", "simple");
-            node.add("LogoURL.Format", format);
         }
     }
 

--- a/src/configurations/Metadata.h
+++ b/src/configurations/Metadata.h
@@ -204,11 +204,8 @@ public:
      * \param[in] parent Node to whom add the metadata node
      */
     void add_node_wmts(ptree& parent) {
-        ptree& node = parent.add("MetadataURL", "");
-        node.add("<xmlattr>.type", type);
-        node.add("Format", format);
-        node.add("OnlineResource.<xmlattr>.xlink:href", href);
-        node.add("OnlineResource.<xmlattr>.xlink:type", "simple");
+        ptree& node = parent.add("ows:Metadata", "");
+        node.add("<xmlattr>.xlink:href", href);
     }
 
     json11::Json to_json_tiles(std::string title, std::string rel) const {

--- a/src/services/Router.cpp
+++ b/src/services/Router.cpp
@@ -174,6 +174,7 @@ void print_fcgi_error ( int error ) {
  */
 int sendresponse ( DataStream* stream, Request* request ) {
 
+
     // Creation de l'en-tete
     std::string statusHeader= get_status_header ( stream->get_http_status() );
     FCGX_PutStr ( statusHeader.data(),statusHeader.size(),request->fcgx_request->out );
@@ -182,7 +183,10 @@ int sendresponse ( DataStream* stream, Request* request ) {
         FCGX_PutStr ( "Content-Type: ",14,request->fcgx_request->out );
         FCGX_PutStr ( stream->get_type().c_str(), strlen ( stream->get_type().c_str() ),request->fcgx_request->out );
     }
-
+    if (stream->get_encoding() != "" ){
+        FCGX_PutStr ( "\r\nContent-Encoding: ",20,request->fcgx_request->out );
+        FCGX_PutStr ( stream->get_encoding().c_str(), strlen ( stream->get_encoding().c_str() ),request->fcgx_request->out );
+    }
     if ( stream->get_length() != 0 ) {
         std::stringstream ss;
         ss << stream->get_length();

--- a/src/services/wms/getmap.cpp
+++ b/src/services/wms/getmap.cpp
@@ -300,6 +300,7 @@ DataStream* WmsService::get_map ( Request* req, Rok4Server* serv ) {
         final_image = images.at(0);
     }
 
+    final_image->set_bbox(bbox);
     final_image->set_crs(crs);
 
     if (format == "image/png" && sample_format == SampleFormat::UINT8) {


### PR DESCRIPTION
### [Fixed]

* `WMS`
  * Correction de l'attribution dans les capacités : contenu du logo et ordre des balises
  * Correction du géoréférencement dans les réponses GeoTIFF

* `TMS`
  * Correction de l'attribution dans les capacités : contenu du logo
  * Ajout du header `Content-Encoding: defalte` pour les tuiles bil compressées

* `WMTS`
  * Correction des balises de métadonnées dans les capacités
  * Ajout du header `Content-Encoding: defalte` pour les tuiles bil compressées